### PR TITLE
added "static" keyword to balance method

### DIFF
--- a/src/Mobily.php
+++ b/src/Mobily.php
@@ -26,7 +26,7 @@ class Mobily extends Controller
         static::$passAccount = config('mobilysms.password');
     }
 
-    public function Balance()
+    public static function Balance()
     {
         static::run();
         $url = "http://www.mobily.ws/api/balance.php";


### PR DESCRIPTION
just added "**static**" keyword to the balance method to be able to invoke the method like instructed in README `Mobily::Balance()`

thank you so much for the helpful package.